### PR TITLE
fix#20: mkdir aarch64-linux-gnu if not there

### DIFF
--- a/7.0.1/Dockerfile
+++ b/7.0.1/Dockerfile
@@ -95,6 +95,7 @@ RUN set -x; \
         && rm /tmp/LICENSE-Community.txt \
 	&& wget -O "/tmp/libstdc++.so.6.0.29" "https://github.com/themattman/raspberrypi-binaries/raw/main/libstdc%2B%2B/libstdc%2B%2B.so.6.0.29" \
 	&& mv "/tmp/libstdc++.so.6.0.29" "/usr/local/lib/libstdc++.so.6.0.29" \
+	&& [ ! -d /lib/aarch64-linux-gnu/ ] && mkdir /lib/aarch64-linux-gnu/ \
 	&& ln -sf "/usr/local/lib/libstdc++.so.6.0.29" "/lib/aarch64-linux-gnu/libstdc++.so.6"
 VOLUME /data/db /data/configdb
 

--- a/7.0.14/Dockerfile
+++ b/7.0.14/Dockerfile
@@ -97,6 +97,7 @@ RUN set -x; \
         && rm /tmp/LICENSE-Community.txt \
 	&& wget -O "/tmp/libstdc++.so.6.0.29" "https://github.com/themattman/raspberrypi-binaries/raw/main/libstdc%2B%2B/libstdc%2B%2B.so.6.0.29" \
 	&& mv "/tmp/libstdc++.so.6.0.29" "/usr/local/lib/libstdc++.so.6.0.29" \
+	&& [ ! -d /lib/aarch64-linux-gnu/ ] && mkdir /lib/aarch64-linux-gnu/ \
 	&& ln -sf "/usr/local/lib/libstdc++.so.6.0.29" "/lib/aarch64-linux-gnu/libstdc++.so.6"
 VOLUME /data/db /data/configdb
 


### PR DESCRIPTION
This PR fixes #20

It first checks if the  /lib/aarch64-linux-gnu exists, if not it creates it.

For now, the fix is only part of the 7.0.14